### PR TITLE
Unbreak the build.

### DIFF
--- a/llama.cpp
+++ b/llama.cpp
@@ -62,6 +62,7 @@
 #include <cstdio>
 #include <cstring>
 #include <ctime>
+#include <cfloat>
 #include <forward_list>
 #include <fstream>
 #include <functional>


### PR DESCRIPTION
Missing header so the build fails with the reference to MAX_FLT

Needs `#include <cfloat>`